### PR TITLE
Add Liquidation subscription support for Binance

### DIFF
--- a/src/exchange/binance/model.rs
+++ b/src/exchange/binance/model.rs
@@ -420,6 +420,7 @@ mod tests {
                 }),
             },
             TestCase {
+                // TC4: valid BinanceMessage FuturePerpetualUsd Liquidation
                 input: r#"{
                     "e": "forceOrder",
                     "E": 1665523974222,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,15 @@ impl ExchangeId {
             _ => false,
         }
     }
+
+    /// Determines whether this [`ExchangeId`] supports the collection of
+    /// liquidation orders market data
+    pub fn supports_liquidations(&self) -> bool {
+        match self {
+            ExchangeId::BinanceFuturesUsd => true,
+            _ => false,
+        }
+    }
 }
 
 /// Consume [`WsMessage`]s transmitted from the [`ExchangeTransformer`] and send them on to the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,8 @@ impl ExchangeId {
     }
 
     /// Determines whether this [`ExchangeId`] supports the collection of
-    /// liquidation orders market data
+    /// liquidation orders market data.
+    #[allow(clippy::match_like_matches_macro)]
     pub fn supports_liquidations(&self) -> bool {
         match self {
             ExchangeId::BinanceFuturesUsd => true,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -26,6 +26,7 @@ pub enum DataKind {
     Trade(PublicTrade),
     Candle(Candle),
     OrderBook(OrderBook),
+    Liquidation(Liquidation),
 }
 
 /// Normalised Barter [`PublicTrade`] model.
@@ -64,6 +65,15 @@ pub struct OrderBook {
 pub struct Level {
     pub price: f64,
     pub quantity: f64,
+}
+
+/// Normalised Barter [`Liquidation`] model.
+#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Deserialize, Serialize)]
+pub struct Liquidation {
+    pub side: Side,
+    pub price: f64,
+    pub quantity: f64,
+    pub time: DateTime<Utc>,
 }
 
 impl<T> From<(T, T)> for Level

--- a/src/model/subscription.rs
+++ b/src/model/subscription.rs
@@ -351,6 +351,15 @@ mod tests {
                 input: r##"{"exchange": "binance_futures_usd", "base": "btc", "quote": "usd", "instrument_type": "future_perpetual", "type": "unknown"}"##,
                 expected: Err(serde_json::Error::custom("")),
             },
+            TestCase {
+                // Valid BinanceFuturesUsd btc_usd FuturePerpetual Liquidation Subscription,
+                input: r##"{"exchange": "binance_futures_usd", "base": "btc", "quote": "usd", "instrument_type": "future_perpetual", "type": "liquidation"}"##,
+                expected: Ok(Subscription {
+                    exchange: ExchangeId::BinanceFuturesUsd,
+                    instrument: Instrument::from(("btc", "usd", InstrumentKind::FuturePerpetual)),
+                    kind: SubKind::Liquidation,
+                }),
+            },
         ];
 
         for (index, test) in cases.into_iter().enumerate() {
@@ -503,6 +512,19 @@ mod tests {
                     exchange: ExchangeId::Kraken,
                     instrument: Instrument::from(("btc", "usd", InstrumentKind::Spot)),
                     kind: SubKind::Candle(Interval::Minute5),
+                }),
+            },
+            TestCase {
+                // Valid Subscription /w BinanceFuturesUsd FuturePerpetual Liquidation
+                input: Subscription {
+                    exchange: ExchangeId::BinanceFuturesUsd,
+                    instrument: Instrument::from(("btc", "usd", InstrumentKind::FuturePerpetual)),
+                    kind: SubKind::Liquidation,
+                },
+                expected: Ok(Subscription {
+                    exchange: ExchangeId::BinanceFuturesUsd,
+                    instrument: Instrument::from(("btc", "usd", InstrumentKind::FuturePerpetual)),
+                    kind: SubKind::Liquidation,
                 }),
             },
         ];

--- a/src/model/subscription.rs
+++ b/src/model/subscription.rs
@@ -45,6 +45,7 @@ impl Validator for &Subscription {
             SubKind::Trade if self.exchange.supports_trades() => {}
             SubKind::Candle(_) if self.exchange.supports_candles() => {}
             SubKind::OrderBook if self.exchange.supports_order_books() => {}
+            SubKind::Liquidation if self.exchange.supports_liquidations() => {}
             other => {
                 return Err(SocketError::Unsupported {
                     entity: self.exchange.as_str(),
@@ -118,6 +119,7 @@ pub enum SubKind {
     OrderBook,
     OrderBookL2Delta,
     OrderBookL3Delta,
+    Liquidation,
 }
 
 impl Display for SubKind {
@@ -131,6 +133,7 @@ impl Display for SubKind {
                 SubKind::OrderBook => "order_book".to_owned(),
                 SubKind::OrderBookL2Delta => "order_book_l2_delta".to_owned(),
                 SubKind::OrderBookL3Delta => "order_book_l3_delta".to_owned(),
+                SubKind::Liquidation => "liquidation".to_owned(),
             }
         )
     }


### PR DESCRIPTION
This PR adds support for the user to subscribe to the liquidation websocket stream on Binance and also add a base for adding liquidation support to other exchanges