### PR TITLE
Public OrderBookSide and bigger orderbook for init

### DIFF
--- a/src/exchange/binance/spot/l2.rs
+++ b/src/exchange/binance/spot/l2.rs
@@ -166,7 +166,7 @@ impl OrderBookUpdater for BinanceSpotBookUpdater {
     {
         // Construct initial OrderBook snapshot GET url
         let snapshot_url = format!(
-            "{}?symbol={}{}&limit=100",
+            "{}?symbol={}{}&limit=5000",
             HTTP_BOOK_L2_SNAPSHOT_URL_BINANCE_SPOT,
             instrument.base.as_ref().to_uppercase(),
             instrument.quote.as_ref().to_uppercase()

--- a/src/subscription/book.rs
+++ b/src/subscription/book.rs
@@ -118,8 +118,8 @@ impl OrderBook {
 /// Normalised Barter [`Level`]s for one [`Side`] of the [`OrderBook`].
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
 pub struct OrderBookSide {
-    side: Side,
-    levels: Vec<Level>,
+    pub side: Side,
+    pub levels: Vec<Level>,
 }
 
 impl OrderBookSide {


### PR DESCRIPTION
We can get OrderBookSide for example with a stream, and if we want to reach the inner data we can't becease it was private. I made public so we don't have to convert to JSON to interact with the data.

Also changed the initial snapshot to be the highest limit possible, so we can maintain deeper orderbook and we have much more details.