### PR TITLE
Fix/37

### DIFF
--- a/src/exchange/binance/book/l2.rs
+++ b/src/exchange/binance/book/l2.rs
@@ -60,7 +60,8 @@ pub struct BinanceOrderBookL2Snapshot {
 impl From<BinanceOrderBookL2Snapshot> for OrderBook {
     fn from(snapshot: BinanceOrderBookL2Snapshot) -> Self {
         Self {
-            last_update_time: snapshot.time,
+            exchange_update_time: snapshot.time,
+            last_update_time: Utc::now(),
             bids: OrderBookSide::new(Side::Buy, snapshot.bids),
             asks: OrderBookSide::new(Side::Sell, snapshot.asks),
         }

--- a/src/exchange/binance/futures/l2.rs
+++ b/src/exchange/binance/futures/l2.rs
@@ -519,6 +519,7 @@ mod tests {
                         last_update_id: 100,
                     },
                     book: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: time,
                         bids: OrderBookSide::new(Side::Buy, vec![Level::new(50, 1)]),
                         asks: OrderBookSide::new(Side::Sell, vec![Level::new(100, 1)]),
@@ -541,6 +542,7 @@ mod tests {
                         last_update_id: 100,
                     },
                     book: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: time,
                         bids: OrderBookSide::new(
                             Side::Buy,
@@ -583,6 +585,7 @@ mod tests {
                         time: Default::default(),
                     },
                     expected: Ok(Some(OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: time,
                         bids: OrderBookSide::new(
                             Side::Buy,

--- a/src/exchange/binance/futures/l2.rs
+++ b/src/exchange/binance/futures/l2.rs
@@ -11,7 +11,7 @@ use barter_integration::{
     model::{instrument::Instrument, SubscriptionId},
     protocol::websocket::WsMessage,
 };
-use chrono::Utc;
+use chrono::{Utc, DateTime};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -58,6 +58,12 @@ pub struct BinanceFuturesOrderBookL2Delta {
     pub bids: Vec<BinanceLevel>,
     #[serde(alias = "a")]
     pub asks: Vec<BinanceLevel>,
+    #[serde(
+        alias = "E",
+        deserialize_with = "barter_integration::de::de_u64_epoch_ms_as_datetime_utc",
+        default = "Utc::now"
+    )]
+    pub time: DateTime<Utc>,
 }
 
 impl Identifier<Option<SubscriptionId>> for BinanceFuturesOrderBookL2Delta {
@@ -233,6 +239,10 @@ mod tests {
     use super::*;
 
     mod de {
+        use std::time::Duration;
+
+        use barter_integration::de::datetime_utc_from_epoch_duration;
+
         use super::*;
 
         #[test]
@@ -275,7 +285,8 @@ mod tests {
                     asks: vec![BinanceLevel {
                         price: 0.0026,
                         amount: 100.0
-                    },]
+                    },],
+                    time: datetime_utc_from_epoch_duration(Duration::from_millis(123_456_789))
                 }
             );
         }
@@ -341,6 +352,7 @@ mod tests {
                         prev_last_update_id: 90,
                         bids: vec![],
                         asks: vec![],
+                        time: Default::default(),
                     },
                     expected: Ok(()),
                 },
@@ -357,6 +369,7 @@ mod tests {
                         prev_last_update_id: 90,
                         bids: vec![],
                         asks: vec![],
+                        time: Default::default(),
                     },
                     expected: Err(DataError::InvalidSequence {
                         prev_last_update_id: 100,
@@ -376,6 +389,7 @@ mod tests {
                         prev_last_update_id: 90,
                         bids: vec![],
                         asks: vec![],
+                        time: Default::default(),
                     },
                     expected: Err(DataError::InvalidSequence {
                         prev_last_update_id: 100,
@@ -395,6 +409,7 @@ mod tests {
                         prev_last_update_id: 90,
                         bids: vec![],
                         asks: vec![],
+                        time: Default::default(),
                     },
                     expected: Err(DataError::InvalidSequence {
                         prev_last_update_id: 100,
@@ -442,6 +457,7 @@ mod tests {
                         prev_last_update_id: 100,
                         bids: vec![],
                         asks: vec![],
+                        time: Default::default(),
                     },
                     expected: Ok(()),
                 },
@@ -458,6 +474,7 @@ mod tests {
                         prev_last_update_id: 90,
                         bids: vec![],
                         asks: vec![],
+                        time: Default::default(),
                     },
                     expected: Err(DataError::InvalidSequence {
                         prev_last_update_id: 100,
@@ -513,6 +530,7 @@ mod tests {
                         prev_last_update_id: 0,
                         bids: vec![],
                         asks: vec![],
+                        time: Default::default(),
                     },
                     expected: Ok(None),
                 },
@@ -562,6 +580,7 @@ mod tests {
                                 amount: 0.0,
                             },
                         ],
+                        time: Default::default(),
                     },
                     expected: Ok(Some(OrderBook {
                         last_update_time: time,

--- a/src/exchange/binance/spot/l2.rs
+++ b/src/exchange/binance/spot/l2.rs
@@ -218,7 +218,7 @@ impl OrderBookUpdater for BinanceSpotBookUpdater {
         // Update OrderBook metadata & Levels:
         // 7. The data in each event is the absolute quantity for a price level.
         // 8. If the quantity is 0, remove the price level.
-        book.last_update_time = update.time;
+        book.last_update_time = Utc::now();
         book.bids.upsert(update.bids);
         book.asks.upsert(update.asks);
 
@@ -500,6 +500,7 @@ mod tests {
                 expected: Result<Option<OrderBook>, DataError>,
             }
 
+            let exchange_time = Utc::now();
             let time = Utc::now();
 
             let tests = vec![
@@ -511,6 +512,7 @@ mod tests {
                         prev_last_update_id: 0,
                     },
                     book: OrderBook {
+                        exchange_update_time: exchange_time,
                         last_update_time: time,
                         bids: OrderBookSide::new(Side::Buy, vec![Level::new(50, 1)]),
                         asks: OrderBookSide::new(Side::Sell, vec![Level::new(100, 1)]),
@@ -533,6 +535,7 @@ mod tests {
                         prev_last_update_id: 100,
                     },
                     book: OrderBook {
+                        exchange_update_time: exchange_time,
                         last_update_time: time,
                         bids: OrderBookSide::new(
                             Side::Buy,
@@ -574,6 +577,7 @@ mod tests {
                         time: Default::default(),
                     },
                     expected: Ok(Some(OrderBook {
+                        exchange_update_time: exchange_time,
                         last_update_time: time,
                         bids: OrderBookSide::new(
                             Side::Buy,

--- a/src/subscription/book.rs
+++ b/src/subscription/book.rs
@@ -73,6 +73,7 @@ impl SubKind for OrderBooksL3 {
 /// Normalised Barter [`OrderBook`] snapshot.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
 pub struct OrderBook {
+    /// Exchange given timestamp of the last orderbook update 
     pub last_update_time: DateTime<Utc>,
     pub bids: OrderBookSide,
     pub asks: OrderBookSide,

--- a/src/subscription/book.rs
+++ b/src/subscription/book.rs
@@ -73,7 +73,9 @@ impl SubKind for OrderBooksL3 {
 /// Normalised Barter [`OrderBook`] snapshot.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Deserialize, Serialize)]
 pub struct OrderBook {
-    /// Exchange given timestamp of the last orderbook update 
+    /// Exchange generated timestamp of the last orderbook event
+    pub exchange_update_time: DateTime<Utc>,
+    /// Local timestamp of the last orderbook update
     pub last_update_time: DateTime<Utc>,
     pub bids: OrderBookSide,
     pub asks: OrderBookSide,
@@ -277,7 +279,7 @@ pub fn volume_weighted_mid_price(best_bid: Level, best_ask: Level) -> f64 {
 impl From<(ExchangeId, Instrument, OrderBook)> for MarketIter<OrderBook> {
     fn from((exchange_id, instrument, book): (ExchangeId, Instrument, OrderBook)) -> Self {
         Self(vec![Ok(MarketEvent {
-            exchange_time: book.last_update_time,
+            exchange_time: book.exchange_update_time,
             received_time: Utc::now(),
             exchange: Exchange::from(exchange_id),
             instrument,
@@ -396,6 +398,7 @@ mod tests {
                 TestCase {
                     // TC0: no levels so 0.0 mid-price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -411,6 +414,7 @@ mod tests {
                 TestCase {
                     // TC1: no asks in the book so take best bid price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -426,6 +430,7 @@ mod tests {
                 TestCase {
                     // TC2: no bids in the book so take ask price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -441,6 +446,7 @@ mod tests {
                 TestCase {
                     // TC3: best bid and ask amount is the same, so regular mid-price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -471,6 +477,7 @@ mod tests {
                 TestCase {
                     // TC0: no levels so 0.0 mid-price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -486,6 +493,7 @@ mod tests {
                 TestCase {
                     // TC1: no asks in the book so take best bid price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -501,6 +509,7 @@ mod tests {
                 TestCase {
                     // TC2: no bids in the book so take ask price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -516,6 +525,7 @@ mod tests {
                 TestCase {
                     // TC3: best bid and ask amount is the same, so regular mid-price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,
@@ -531,6 +541,7 @@ mod tests {
                 TestCase {
                     // TC4: valid volume weighted mid-price
                     input: OrderBook {
+                        exchange_update_time: Default::default(),
                         last_update_time: Default::default(),
                         bids: OrderBookSide {
                             side: Side::Buy,


### PR DESCRIPTION
Add the field `exchange_update_time` to track the exchange timestamp of orderbook events

`last_update_time` is left as is representing the local timestamp of orderbook update

fixes #37 