### PR TITLE
Add time frame/series element to Candle struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barter-data"
-version = "0.6.9"
+version = "0.7.0"
 authors = ["JustAStream"]
 edition = "2021"
 license = "MIT"

--- a/src/exchange/coinbase/trade.rs
+++ b/src/exchange/coinbase/trade.rs
@@ -115,13 +115,14 @@ mod tests {
                     price: 400.23,
                     amount: 5.23512,
                     side: Side::Sell,
-                    time: DateTime::from_utc(
+                    time: DateTime::from_naive_utc_and_offset(
                         NaiveDateTime::from_str("2014-11-07T08:19:27.028459").unwrap(),
                         Utc,
                     ),
                 }),
             },
         ];
+
 
         for (index, test) in cases.into_iter().enumerate() {
             let actual = serde_json::from_str::<CoinbaseTrade>(test.input);

--- a/src/exchange/kraken/trade.rs
+++ b/src/exchange/kraken/trade.rs
@@ -51,7 +51,7 @@ impl Identifier<Option<SubscriptionId>> for KrakenTradesInner {
 fn custom_kraken_trade_id(trade: &KrakenTrade) -> String {
     format!(
         "{}_{}_{}_{}",
-        trade.time.timestamp_nanos(),
+        trade.time.timestamp_nanos_opt().unwrap_or(trade.time.timestamp_millis() * 1000),
         trade.side,
         trade.price,
         trade.amount

--- a/src/subscription/candle.rs
+++ b/src/subscription/candle.rs
@@ -15,11 +15,13 @@ impl SubKind for Candles {
 pub enum TimeSeries {
     OneMinute,
     FiveMinutes,
+    FifteenMinutes,
+    ThirtyMinutes,
     OneHour,
     FourHours,
-    Day,
-    Week,
-    Month,
+    Daily,
+    Weekly,
+    Monthly,
 }
 
 /// Normalised Barter OHLCV [`Candle`] model.


### PR DESCRIPTION
Part of a series of changes to ultimately deliver https://github.com/barter-rs/barter-rs/issues/21 i.e. create strategies that utilise multiple timeframes. This is the first modification to add TimeSeries to Candle/OHLCV ticks.

Also replaced some deprecated calls - all tests pass.